### PR TITLE
Fix CSRF token mismatch issues

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -40,7 +40,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\SetLocale::class, // Add SetLocale middleware


### PR DESCRIPTION
- Enable EnsureFrontendRequestsAreStateful middleware for SPA authentication.
- Verify Sanctum, session, and CORS configurations for proper CSRF handling with the Next.js frontend.